### PR TITLE
Peyton/fix image url handling

### DIFF
--- a/pkg/api/v1/apiv1.go
+++ b/pkg/api/v1/apiv1.go
@@ -185,7 +185,7 @@ func (s *Service) GenerateImage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if bod.DummyMode {
-		fmt.Fprintln(w, envs.DALLE_E_DUMMY_LINK)
+		fmt.Fprint(w, envs.DALLE_E_DUMMY_LINK)
 		return
 	}
 	url, err := s.dalle.Prompt(ctx, &bod)
@@ -194,7 +194,7 @@ func (s *Service) GenerateImage(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	fmt.Fprintln(w, url)
+	fmt.Fprint(w, url)
 
 	s.sd.Run(func(ctx context.Context) {
 		slog.Debug("image receipt", "url", url)
@@ -298,7 +298,7 @@ func (s *Service) PresignURL(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	fmt.Fprintln(w, url)
+	fmt.Fprint(w, url)
 }
 
 // - MARK: create-upload-url
@@ -331,7 +331,7 @@ func (s *Service) CreateUploadURL(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	fmt.Fprintln(w, url)
+	fmt.Fprint(w, url)
 }
 
 // - MARK: get-memories

--- a/types/rp/response-types.go
+++ b/types/rp/response-types.go
@@ -156,6 +156,7 @@ func TrimStuff(s *string, prefix, suffix string, replaceFunc func(*string) error
 			result = result[:resultIdx] + result[resultIdx+len(prefix)+len(afterPrefix[:closeIdx])+len(suffix):]
 		} else {
 			url := afterPrefix[:closeIdx]
+			url = strings.TrimSuffix(url, "\n") // Trim any trailing newlines that might have been added
 			err := replaceFunc(&url)
 			if err != nil {
 				return err


### PR DESCRIPTION
Quickfix trim newlines on URLs and forward looking fix USE Fprint NOT Fprintln.
Can clean the backend DB for the newlines but not priority.